### PR TITLE
chore(renovaterc): pnpm can now use latest

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,3 @@
 {
-  "extends":["github>form8ion/renovate-config:js-package"],
-  "ignoreDeps": ["pnpm"]
+  "extends":["github>form8ion/renovate-config:js-package"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8934,9 +8934,9 @@
       "dev": true
     },
     "pnpm": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-5.5.11.tgz",
-      "integrity": "sha512-427eDz+GA6tiQoWmhMzv/xFCDRI9g8cEsaVNf3pCasqU/Yt3oRA8ekOPcJMNfkWQ7DSZJg1i4MY9RA6WtnwS8g==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-5.8.0.tgz",
+      "integrity": "sha512-J2rAxEXnohwcDkR4KNI6UsYhDs9hJ/tje/BahHpXawi406pmxd6caJUXfRxZPbKvKdyVqfBRKhlX1vyhYbM8lQ==",
       "dev": true
     },
     "pop-iterate": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
     "package-preview": "3.0.0",
-    "pnpm": "5.5.11",
+    "pnpm": "5.8.0",
     "remark": "12.0.1",
     "remark-cli": "8.0.1",
     "remark-preset-lint-travi": "1.3.10",


### PR DESCRIPTION
- it seems that the version of the cli that package-preview
pulls in is still broken with our setup, but the core pnpm
package itself works as expected. This at least gets us to
a point where we are getting new updates, but we still can't
get rid of pnpm as a direct dev dep yet