### PR TITLE
chore(package): remove pnpm entirely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8933,12 +8933,6 @@
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
     },
-    "pnpm": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-5.8.0.tgz",
-      "integrity": "sha512-J2rAxEXnohwcDkR4KNI6UsYhDs9hJ/tje/BahHpXawi406pmxd6caJUXfRxZPbKvKdyVqfBRKhlX1vyhYbM8lQ==",
-      "dev": true
-    },
     "pop-iterate": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pop-iterate/-/pop-iterate-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "npm-run-all": "4.1.5",
     "nyc": "15.1.0",
     "package-preview": "3.0.0",
-    "pnpm": "5.8.0",
     "remark": "12.0.1",
     "remark-cli": "8.0.1",
     "remark-preset-lint-travi": "1.3.10",


### PR DESCRIPTION
- i had accidentally installed pnpm globally so it was finding that which was an old version 🤦‍♂️
after removing that and blowing away node_modules and reinstall everything worked
so I think we're gtg. it appears to reinstall latest for us, which does work.